### PR TITLE
Change demo app title to Demonstration App

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Apicurio Common UI Components Demo</title>
+    <title>Apicurio Common UI Components Demonstration App</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Fixes #1

Updated the title in index.html from 'Apicurio Common UI Components Demo' to 'Apicurio Common UI Components Demonstration App' as requested in the issue.

This change affects only the HTML page title visible in the browser tab.