### PR TITLE
Upgrade @types/node to version 20.19.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@patternfly/react-icons": "5.4.2",
     "@patternfly/react-table": "5.4.16",
     "@types/luxon": "3.7.1",
-    "@types/node": "20.19.13",
+    "@types/node": "20.19.30",
     "@types/react": "18.3.24",
     "@types/react-dom": "18.3.7",
     "@typescript-eslint/eslint-plugin": "8.42.0",


### PR DESCRIPTION
Fixes #3

This PR upgrades the `@types/node` dependency from version 20.19.13 to 20.19.30 as requested in issue #3.

## Changes
- Updated `@types/node` from `20.19.13` to `20.19.30` in package.json

## Rationale
This is a minor patch version update within the same major version (20.19.x) that includes bug fixes and type improvements for Node.js TypeScript definitions.